### PR TITLE
Add missing codes to cache for NC refusal create along with title dec…

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/nc/utils/NamedHouseholderRetrieval.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/nc/utils/NamedHouseholderRetrieval.java
@@ -78,9 +78,14 @@ public class NamedHouseholderRetrieval {
             if (householdContact != null) {
               String decryptedFirstname;
               String decryptedSurname;
+              String decryptedTitle;
               String isHouseHolder;
 
               try {
+                decryptedTitle = !householdContact.get("title").toString().equals("") ? DecryptNames.decryptFile(
+                    privateKey.getInputStream(), householdContact.get("title").toString(),
+                    privateKeyPassword.toCharArray()) : "";
+
                 decryptedFirstname = !householdContact.get("forename").toString().equals("") ? DecryptNames.decryptFile(
                     privateKey.getInputStream(), householdContact.get("forename").toString(),
                     privateKeyPassword.toCharArray()) : "";
@@ -96,13 +101,16 @@ public class NamedHouseholderRetrieval {
               isHouseHolder =  collectionCase.get("isHouseholder") != null && collectionCase.get("isHouseholder").toString().equals("true") ? "Yes" : "No";
 
               if (decryptedSurname != null) {
-                contact.append(" ").append(decryptedSurname).append(" ");
-                if (decryptedFirstname != null) {
-                  contact.insert(0, " " + decryptedFirstname);
+                contact.insert(0, "Name =");
+                if (decryptedTitle != null) {
+                  contact.append(" ").append(decryptedTitle);
                 }
+                if (decryptedFirstname != null) {
+                  contact.append(" ").append(decryptedFirstname);
+                }
+                contact.append(" ").append(decryptedSurname).append("\n");
                 // Do we need a placeholder in the description to say that this is the name of the householder?
                 // I've added one temporarily
-                contact.insert(0, "Householder name = ");
                 contact.append("Named householder = ").append(isHouseHolder);
                 eventManager.triggerEvent(caseId,DECRYPTED_HH_NAMES);
                 break;

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/nc/NcCeCreateEnglandAndWales.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/nc/NcCeCreateEnglandAndWales.java
@@ -68,6 +68,8 @@ public class NcCeCreateEnglandAndWales implements InboundProcessor<FwmtActionIns
   public void process(FwmtActionInstruction rmRequest, GatewayCache cache, Instant messageReceivedTime)
       throws GatewayException {
     String newCaseId = String.valueOf(UUID.randomUUID());
+    String accessInfo = null;
+    String careCodes = null;
 
     CaseRequest tmRequest = NcCreateConverter.convertNcEnglandAndWales(rmRequest, cache, null);
 
@@ -84,12 +86,20 @@ public class NcCeCreateEnglandAndWales implements InboundProcessor<FwmtActionIns
         "cache", (cache != null) ? cache.toString() : "");
 
     GatewayCache newCache = cacheService.getById(newCaseId);
+
+    if (cache != null) {
+      careCodes =  cache.getCareCodes();
+      accessInfo = cache.getAccessInfo();
+    }
+
     if (newCache == null) {
       cacheService.save(GatewayCache
           .builder()
           .caseId(newCaseId)
           .originalCaseId(rmRequest.getCaseId())
           .existsInFwmt(true)
+          .careCodes(careCodes)
+          .accessInfo(accessInfo)
           .type(1)
           .lastActionInstruction(rmRequest.getActionInstruction().toString())
           .lastActionTime(messageReceivedTime)

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/nc/NcHhCreateEnglandAndWales.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/nc/NcHhCreateEnglandAndWales.java
@@ -77,6 +77,8 @@ public class NcHhCreateEnglandAndWales implements InboundProcessor<FwmtActionIns
   public void process(FwmtActionInstruction rmRequest, GatewayCache cache, Instant messageReceivedTime)
       throws GatewayException {
     CaseDetailsDTO houseHolderDetails;
+    String accessInfo = null;
+    String careCodes = null;
 
     try {
       houseHolderDetails = rmRestClient.getCase(rmRequest.getCaseId());
@@ -102,6 +104,12 @@ public class NcHhCreateEnglandAndWales implements InboundProcessor<FwmtActionIns
         "cache", (cache != null) ? cache.toString() : "");
 
     GatewayCache newCache = cacheService.getById(newCaseId);
+
+    if (cache != null) {
+      careCodes =  cache.getCareCodes();
+      accessInfo = cache.getAccessInfo();
+    }
+
     if (newCache == null) {
       cacheService.save(GatewayCache
           .builder()
@@ -109,6 +117,8 @@ public class NcHhCreateEnglandAndWales implements InboundProcessor<FwmtActionIns
           .originalCaseId(rmRequest.getCaseId())
           .existsInFwmt(true)
           .type(10)
+          .careCodes(careCodes)
+          .accessInfo(accessInfo)
           .lastActionInstruction(rmRequest.getActionInstruction().toString())
           .lastActionTime(messageReceivedTime)
           .build());


### PR DESCRIPTION
…ryption and updated description message

# Issue Summary
https://collaborate2.ons.gov.uk/jira/browse/FWMT-2688

# Proposed Changes
Caching of careCodes and accessCodes was missing for a create NC hard refusal. Encrypted title needed to be decrypted and an update to the description was required. These have all been fixed/updated.

# Additional Info
Run NC HH create hard refusal

# Checklist
- [ ] Tests
- [x] Sensitive Data not being logged
- [ ] Documentation Updated ( where required)


# How it was tested
- [ ] Unit tested
- [ ] Ran the acceptance tests
- [x] Manually Tested
- [ ] Not tested becase my coding skills are flawless


# Screenshots
