### PR TITLE
Have set usual resident count to 0 when a CE_Site is received. Have a…

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessor.java
@@ -123,7 +123,7 @@ public class CeSwitchCreateProcessor implements InboundProcessor<FwmtActionInstr
     routingValidator.validateResponseCode(reopenResponse, rmRequest.getCaseId(), "Reopen", FAILED_TO_REOPEN_TM_JOB, "tmRequest", tmRequest.toString(), "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
 
     if(cache != null) {
-      if (rmRequest.getAddressType().equals(SurveyType.CE_SITE.toString())) {
+      if (rmRequest.getSurveyType().equals(SurveyType.CE_SITE)) {
         cacheService.save(cache.toBuilder().usualResidents(0).build());
       } else {
         cacheService.save(cache.toBuilder().build());

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessor.java
@@ -87,6 +87,8 @@ public class CeSwitchCreateProcessor implements InboundProcessor<FwmtActionInstr
       cache.setType(2);
       tmRequest = CommonSwitchConverter.convertSite(rmRequest);
       processSwitch(cache, rmRequest, tmRequest);
+    } else if (rmRequest.getSurveyType().equals(SurveyType.CE_SITE) && (cache!=null) && cache.getType() == 2) {
+      eventManager.triggerEvent(rmRequest.getCaseId(), "Case is already a site");
     } else if (rmRequest.getSurveyType().equals(SurveyType.CE_UNIT_D)) {
       cache.setType(3);
       tmRequest = CommonSwitchConverter.convertUnitDeliver(rmRequest);
@@ -121,7 +123,11 @@ public class CeSwitchCreateProcessor implements InboundProcessor<FwmtActionInstr
     routingValidator.validateResponseCode(reopenResponse, rmRequest.getCaseId(), "Reopen", FAILED_TO_REOPEN_TM_JOB, "tmRequest", tmRequest.toString(), "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
 
     if(cache != null) {
-      cacheService.save(cache.toBuilder().build());
+      if (rmRequest.getAddressType().equals(SurveyType.CE_SITE.toString())) {
+        cacheService.save(cache.toBuilder().usualResidents(0).build());
+      } else {
+        cacheService.save(cache.toBuilder().build());
+      }
     }
 
     eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_REOPEN_ACK, "Survey Type",

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
@@ -4,6 +4,8 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -17,6 +19,8 @@ import uk.gov.ons.census.fwmt.jobservice.service.GatewayCacheService;
 import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
+
+import static org.mockito.Mockito.verify;
 
 @ExtendWith(MockitoExtension.class)
 public class CeSwitchCreateProcessorTest {
@@ -35,6 +39,9 @@ public class CeSwitchCreateProcessorTest {
 
   @Mock
   private GatewayCacheService cacheService;
+
+  @Captor
+  private ArgumentCaptor<GatewayCache> spiedCache;
 
   private FwmtActionInstruction createInstruction() {
     return FwmtActionInstruction.builder().caseRef("345").build();
@@ -62,8 +69,9 @@ public class CeSwitchCreateProcessorTest {
     instruction.setSurveyType(SurveyType.CE_SITE);
     instruction.setCaseId("1234");
     GatewayCache cache = createGatewayCache("1234", 1, 10);
-    cacheService.save(cache);
     ceSwitchCreateProcessor.process(instruction, cache, Instant.now());
-    Assertions.assertEquals(0, cache.getUsualResidents());
+    verify(cacheService).save(spiedCache.capture());
+    int usualResidents = spiedCache.getValue().usualResidents;
+    Assertions.assertEquals(0, usualResidents);
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
@@ -18,6 +18,7 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
+import static org.junit.jupiter.api.Assertions.fail;
 
 @ExtendWith(MockitoExtension.class)
 public class CeSwitchCreateProcessorTest {
@@ -57,8 +58,8 @@ public class CeSwitchCreateProcessorTest {
   }
 
   @Test
-  @DisplayName("Should handle type - CE_EST_D ")
-  public void shouldMessageForCE_EST_D() {
-
+  @DisplayName("Should set usualResident count to 0 when a valid CE_SITE is received")
+  public void shouldHandleCE() {
+    fail("Not implemented");
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
@@ -18,8 +18,6 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
-import static org.junit.jupiter.api.Assertions.fail;
-
 @ExtendWith(MockitoExtension.class)
 public class CeSwitchCreateProcessorTest {
 
@@ -42,8 +40,8 @@ public class CeSwitchCreateProcessorTest {
     return FwmtActionInstruction.builder().caseRef("345").build();
   }
 
-  private GatewayCache createGatewayCache() {
-    return GatewayCache.builder().caseId("").build();
+  private GatewayCache createGatewayCache(String caseId, int type, int usualResidents) {
+    return GatewayCache.builder().caseId(caseId).type(type).usualResidents(usualResidents).build();
   }
 
   @Test
@@ -53,13 +51,19 @@ public class CeSwitchCreateProcessorTest {
     instruction.setSurveyType(SurveyType.AC);
     instruction.setCaseId("1234");
     Assertions.assertThrows(GatewayException.class, () -> {
-      ceSwitchCreateProcessor.process(instruction, createGatewayCache(), Instant.now());
+      ceSwitchCreateProcessor.process(instruction, createGatewayCache("",0,0), Instant.now());
     });
   }
 
   @Test
   @DisplayName("Should set usualResident count to 0 when a valid CE_SITE is received")
-  public void shouldHandleCE() {
-    fail("Not implemented");
+  public void shouldHandleCE() throws GatewayException {
+    final FwmtActionInstruction instruction = createInstruction();
+    instruction.setSurveyType(SurveyType.CE_SITE);
+    instruction.setCaseId("1234");
+    GatewayCache cache = createGatewayCache("1234", 1, 10);
+    cacheService.save(cache);
+    ceSwitchCreateProcessor.process(instruction, cache, Instant.now());
+    Assertions.assertEquals(0, cache.getUsualResidents());
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
@@ -1,10 +1,13 @@
 package uk.gov.ons.census.fwmt.jobservice.service.routing.ce;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ons.census.fwmt.common.data.tm.SurveyType;
 import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtActionInstruction;
 import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
@@ -15,7 +18,6 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @ExtendWith(MockitoExtension.class)
 public class CeSwitchCreateProcessorTest {
@@ -43,21 +45,20 @@ public class CeSwitchCreateProcessorTest {
     return GatewayCache.builder().caseId("").build();
   }
 
-  // what are we going to test here -
   @Test
-  public void shouldTriggerErrorEvent() throws GatewayException {
-
-    FwmtActionInstruction instruction = createInstruction();
-    ceSwitchCreateProcessor.process(instruction, createGatewayCache(), Instant.now());
-
-    assertTrue(false);
+  @DisplayName("Should throw Gateway Exception and trigger event for invalid survey type")
+  public void shouldHandleIncorrectSurveyTypeCE() {
+    final FwmtActionInstruction instruction = createInstruction();
+    instruction.setSurveyType(SurveyType.AC);
+    instruction.setCaseId("1234");
+    Assertions.assertThrows(GatewayException.class, () -> {
+      ceSwitchCreateProcessor.process(instruction, createGatewayCache(), Instant.now());
+    });
   }
 
-  // put in all the outcomes - switch - what comet requests are being made
   @Test
-  public void shouldMessagEcomment() {
-    // put in all the outcomes - switch - what comet requests are being made
+  @DisplayName("Should handle type - CE_EST_D ")
+  public void shouldMessageForCE_EST_D() {
 
-    // what things are happening in that switch ?
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeSwitchCreateProcessorTest.java
@@ -1,0 +1,63 @@
+package uk.gov.ons.census.fwmt.jobservice.service.routing.ce;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ons.census.fwmt.common.error.GatewayException;
+import uk.gov.ons.census.fwmt.common.rm.dto.FwmtActionInstruction;
+import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
+import uk.gov.ons.census.fwmt.jobservice.data.GatewayCache;
+import uk.gov.ons.census.fwmt.jobservice.http.comet.CometRestClient;
+import uk.gov.ons.census.fwmt.jobservice.service.GatewayCacheService;
+import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
+
+import java.time.Instant;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@ExtendWith(MockitoExtension.class)
+public class CeSwitchCreateProcessorTest {
+
+  @InjectMocks
+  private CeSwitchCreateProcessor ceSwitchCreateProcessor;
+
+  @Mock
+  private CometRestClient cometRestClient;
+
+  @Mock
+  private GatewayEventManager eventManager;
+
+  @Mock
+  private RoutingValidator routingValidator;
+
+  @Mock
+  private GatewayCacheService cacheService;
+
+  private FwmtActionInstruction createInstruction() {
+    return FwmtActionInstruction.builder().caseRef("345").build();
+  }
+
+  private GatewayCache createGatewayCache() {
+    return GatewayCache.builder().caseId("").build();
+  }
+
+  // what are we going to test here -
+  @Test
+  public void shouldTriggerErrorEvent() throws GatewayException {
+
+    FwmtActionInstruction instruction = createInstruction();
+    ceSwitchCreateProcessor.process(instruction, createGatewayCache(), Instant.now());
+
+    assertTrue(false);
+  }
+
+  // put in all the outcomes - switch - what comet requests are being made
+  @Test
+  public void shouldMessagEcomment() {
+    // put in all the outcomes - switch - what comet requests are being made
+
+    // what things are happening in that switch ?
+  }
+}


### PR DESCRIPTION
…lso updated incorrect exception throwing when case is already a site

# Summary
[ ] Bug fix ( non-breaking change which fixes issue)
[x] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira: https://collaborate2.ons.gov.uk/jira/browse/FWMT-2842

# Proposed Changes
Have added to the CeSwitchCreateProcessor to updated the usualResident count to 0 when a valid CE_SITE is received. Have also removed the confusing logging around when a CE_SITE is already present.

# Checklist
- [x] Unit Test written 
- [ ] Acceptance Tests updated
- [ ] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )
- [x] Tested locally

# Additional Info
Run a CE unit after running a CE establishment

# Screenshots

- Screen shot of Passed Unit/Acceptance Test

<img width="1664" alt="Screenshot 2021-01-05 at 10 17 10" src="https://user-images.githubusercontent.com/47788084/103634614-396e5c80-4f3f-11eb-83ad-2513849063cb.png">

