### PR TITLE
Have added the initial process to ignore a cancel on a cancel for review

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/config/GatewayEventsConfig.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/config/GatewayEventsConfig.java
@@ -47,6 +47,7 @@ public class GatewayEventsConfig {
   public static final String UNABLE_TO_READ_EVENT_PAYLOAD = "UNABLE_TO_READ_EVENT_PAYLOAD";
   public static final String UNABLE_TO_DECRYPT_NAME = "UNABLE_TO_DECRYPT_NAME";
   public static final String ROUTING_FAILED = "ROUTING_FAILED";
+  public static final String CANCEL_ON_A_CANCEL = "CANCEL_ON_A_CANCEL";
 
   public static final String CONVERT_SPG_UNIT_UPDATE_TO_CREATE = "CONVERT_SPG_UNIT_UPDATE_TO_CREATE";
   public static final String FAILED_TO_ROUTE_REQUEST = "FAILED_TO_ROUTE_REQUEST";

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ccs/CcsInterviewCECancel.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ccs/CcsInterviewCECancel.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.ActionInstructionType;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
@@ -16,6 +17,7 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCEL_ON_A_CANCEL;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_ACK;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_PRE_SENDING;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.FAILED_TO_CANCEL_TM_JOB;
@@ -66,13 +68,23 @@ public class CcsInterviewCECancel implements InboundProcessor<FwmtCancelActionIn
         "Case Ref", "N/A",
         "TM Action", "CLOSE");
 
-    ResponseEntity<Void> response = cometRestClient.sendClose(rmRequest.getCaseId());
-    routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB);
+    try {
+      ResponseEntity<Void> response = cometRestClient.sendClose(rmRequest.getCaseId());
+      routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB);
 
-    eventManager
-        .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
-            "Case Ref", "N/A",
-            "Response Code", response.getStatusCode().name());
-
+      eventManager
+          .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
+              "Case Ref", "N/A",
+              "Response Code", response.getStatusCode().name());
+    } catch (RestClientException e) {
+      String tmResponse = e.getMessage();
+      if (tmResponse != null && tmResponse.contains("400") && tmResponse.contains("Case State must be Open")) {
+        eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), CANCEL_ON_A_CANCEL,
+            "A cancel case has been received for a case that already has been cancelled",
+            "Message received: " + rmRequest.toString());
+      } else {
+        throw e;
+      }
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCancelEstabAndSiteProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCancelEstabAndSiteProcessor.java
@@ -18,6 +18,7 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCEL_ON_A_CANCEL;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_ACK;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_PRE_SENDING;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.FAILED_TO_CANCEL_TM_JOB;
@@ -79,7 +80,7 @@ public class CeCancelEstabAndSiteProcessor implements InboundProcessor<FwmtCance
     } catch (RestClientException e) {
       String tmResponse = e.getMessage();
       if (tmResponse != null && tmResponse.contains("400") && tmResponse.contains("Case State must be Open")){
-        eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), "CANCEL_ON_A_CANCEL",
+        eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), CANCEL_ON_A_CANCEL,
             "A cancel case has been received for a case that already has been cancelled",
             "Message received: " + rmRequest.toString());
         alreadyCancelled = true;

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCancelEstabAndSiteProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCancelEstabAndSiteProcessor.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.ActionInstructionType;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
@@ -65,13 +66,27 @@ public class CeCancelEstabAndSiteProcessor implements InboundProcessor<FwmtCance
 
   @Override
   public void process(FwmtCancelActionInstruction rmRequest, GatewayCache cache, Instant messageReceivedTime) throws GatewayException {
+    boolean alreadyCancelled = false;
+    ResponseEntity<Void> response = null;
     eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_PRE_SENDING,
         "Case Ref", "N/A",
         "TM Action", "CLOSE",
         "Source", "RM");
 
-    ResponseEntity<Void> response = cometRestClient.sendClose(rmRequest.getCaseId());
-    routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB, "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
+    try {
+      response = cometRestClient.sendClose(rmRequest.getCaseId());
+      routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB, "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
+    } catch (RestClientException e) {
+      String tmResponse = e.getMessage();
+      if (tmResponse != null && tmResponse.contains("400") && tmResponse.contains("Case State must be Open")){
+        eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), "CANCEL_ON_A_CANCEL",
+            "A cancel case has been received for a case that already has been cancelled",
+            "Message received: " + rmRequest.toString());
+        alreadyCancelled = true;
+      } else {
+        throw e;
+      }
+    }
 
     GatewayCache newCache = cacheService.getById(rmRequest.getCaseId());
     if (newCache != null) {
@@ -80,9 +95,11 @@ public class CeCancelEstabAndSiteProcessor implements InboundProcessor<FwmtCance
           .build());
     }
 
-    eventManager
-        .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
-            "Case Ref", "N/A",
-            "Response Code", response.getStatusCode().name());
+    if (response != null && !alreadyCancelled) {
+      eventManager
+          .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
+              "Case Ref", "N/A",
+              "Response Code", response.getStatusCode().name());
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCancelUnitProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCancelUnitProcessor.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.ActionInstructionType;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
@@ -17,6 +18,7 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCEL_ON_A_CANCEL;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_ACK;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_PRE_SENDING;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.FAILED_TO_CANCEL_TM_JOB;
@@ -64,13 +66,27 @@ public class CeCancelUnitProcessor implements InboundProcessor<FwmtCancelActionI
 
   @Override
   public void process(FwmtCancelActionInstruction rmRequest, GatewayCache cache, Instant messageReceivedTime) throws GatewayException {
+    boolean alreadyCancelled = false;
+    ResponseEntity<Void> response = null;
     eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_PRE_SENDING,
         "Case Ref", "N/A",
         "TM Action", "CLOSE",
         "Source", "RM");
 
-    ResponseEntity<Void> response = cometRestClient.sendClose(rmRequest.getCaseId());
-    routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB, "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
+    try{
+      response = cometRestClient.sendClose(rmRequest.getCaseId());
+      routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB, "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
+    } catch (RestClientException e) {
+      String tmResponse = e.getMessage();
+      if (tmResponse != null && tmResponse.contains("400") && tmResponse.contains("Case State must be Open")){
+        eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), CANCEL_ON_A_CANCEL,
+            "A cancel case has been received for a case that already has been cancelled",
+            "Message received: " + rmRequest.toString());
+        alreadyCancelled = true;
+      } else {
+        throw e;
+      }
+    }
 
     GatewayCache newCache = cacheService.getById(rmRequest.getCaseId());
     if (newCache != null) {
@@ -79,9 +95,11 @@ public class CeCancelUnitProcessor implements InboundProcessor<FwmtCancelActionI
           .build());
     }
 
-    eventManager
-        .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
-            "Case Ref", "N/A",
-            "Response Code", response.getStatusCode().name());
+    if (response != null && !alreadyCancelled) {
+      eventManager
+          .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
+              "Case Ref", "N/A",
+              "Response Code", response.getStatusCode().name());
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/internal/FeedbackCancel.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/internal/FeedbackCancel.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.ActionInstructionType;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
@@ -17,6 +18,7 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCEL_ON_A_CANCEL;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_ACK;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_PRE_SENDING;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.FAILED_TO_CANCEL_TM_JOB;
@@ -65,15 +67,28 @@ public class FeedbackCancel implements InboundProcessor<FwmtCancelActionInstruct
   @Override
   public void process(FwmtCancelActionInstruction rmRequest, GatewayCache cache, Instant messageReceivedTime)
       throws GatewayException {
+    boolean alreadyCancelled = false;
+    ResponseEntity<Void> response = null;
     eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_PRE_SENDING,
         "Case Ref", "N/A",
         "TM Action", "CLOSE",
         "Source", "Internal");
-
-    ResponseEntity<Void> response = cometRestClient.sendClose(rmRequest.getCaseId());
-    routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB,
-        "rmRequest", rmRequest.toString(),
-        "cache", (cache!=null)?cache.toString():"");
+    try {
+      response = cometRestClient.sendClose(rmRequest.getCaseId());
+      routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB,
+          "rmRequest", rmRequest.toString(),
+          "cache", (cache!=null)?cache.toString():"");
+    } catch (RestClientException e) {
+      String tmResponse = e.getMessage();
+      if (tmResponse != null && tmResponse.contains("400") && tmResponse.contains("Case State must be Open")){
+        eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), CANCEL_ON_A_CANCEL,
+            "A cancel case has been received for a case that already has been cancelled",
+            "Message received: " + rmRequest.toString());
+        alreadyCancelled = true;
+      } else {
+        throw e;
+      }
+    }
 
     GatewayCache newCache = cacheService.getById(rmRequest.getCaseId());
     if (newCache != null) {
@@ -82,11 +97,13 @@ public class FeedbackCancel implements InboundProcessor<FwmtCancelActionInstruct
           .build());
     }
 
-    eventManager
-        .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
-            "Case Ref", "N/A",
-            "Response Code", response.getStatusCode().name(),
-            "Source", "Internal",
-            "Feedback Cancel", rmRequest.toString());
+    if (response != null && !alreadyCancelled) {
+      eventManager
+          .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
+              "Case Ref", "N/A",
+              "Response Code", response.getStatusCode().name(),
+              "Source", "Internal",
+              "Feedback Cancel", rmRequest.toString());
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/nc/NcHhCancel.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/nc/NcHhCancel.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestClientException;
 import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.ActionInstructionType;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
@@ -17,6 +18,7 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCEL_ON_A_CANCEL;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.FAILED_TO_CANCEL_TM_JOB;
 
 @Qualifier("Cancel")
@@ -71,27 +73,42 @@ public class NcHhCancel implements InboundProcessor<FwmtCancelActionInstruction>
   @Override
   public void process(FwmtCancelActionInstruction rmRequest, GatewayCache cache, Instant messageReceivedTime)
       throws GatewayException {
+    boolean alreadyCancelled = false;
+    ResponseEntity<Void> response = null;
     String ncCaseId = cache.caseId;
     eventManager.triggerEvent(String.valueOf(ncCaseId), COMET_CANCEL_PRE_SENDING,
         "Case Ref", "N/A",
         "Type", "NC Cancel",
         "TM Action", "CLOSE",
         "Source", "RM");
+    try {
+      response = cometRestClient.sendClose(ncCaseId);
+      routingValidator.validateResponseCode(response, ncCaseId,
+          "Cancel", FAILED_TO_CANCEL_TM_JOB,
+          "rmRequest", rmRequest.toString(),
+          "cache", cache.toString());
+    } catch (RestClientException e) {
+      String tmResponse = e.getMessage();
+      if (tmResponse != null && tmResponse.contains("400") && tmResponse.contains("Case State must be Open")){
+        eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), CANCEL_ON_A_CANCEL,
+            "A cancel case has been received for a case that already has been cancelled",
+            "Message received: " + rmRequest.toString());
+        alreadyCancelled = true;
+      } else {
+        throw e;
+      }
+    }
 
-    ResponseEntity<Void> response = cometRestClient.sendClose(ncCaseId);
-    routingValidator.validateResponseCode(response, ncCaseId,
-        "Cancel", FAILED_TO_CANCEL_TM_JOB,
-        "rmRequest", rmRequest.toString(),
-        "cache", cache.toString());
+    cacheService.save(cache.toBuilder().lastActionInstruction(rmRequest.getActionInstruction().toString())
+        .lastActionTime(messageReceivedTime)
+        .build());
 
-      cacheService.save(cache.toBuilder().lastActionInstruction(rmRequest.getActionInstruction().toString())
-          .lastActionTime(messageReceivedTime)
-          .build());
-
-    eventManager
-        .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
-            "Case Ref", "N/A",
-            "Type", "NC Cancel",
-            "Response Code", response.getStatusCode().name());
+    if (response != null && !alreadyCancelled) {
+      eventManager
+          .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
+              "Case Ref", "N/A",
+              "Type", "NC Cancel",
+              "Response Code", response.getStatusCode().name());
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/spg/SpgCancelSiteProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/spg/SpgCancelSiteProcessor.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.ActionInstructionType;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
@@ -17,6 +18,7 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCEL_ON_A_CANCEL;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_ACK;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_PRE_SENDING;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.FAILED_TO_CANCEL_TM_JOB;
@@ -71,13 +73,27 @@ public class SpgCancelSiteProcessor implements InboundProcessor<FwmtCancelAction
   // TODO Can event be added in class where its used, rather than config, or can it be added when used first time
   @Override
   public void process(FwmtCancelActionInstruction rmRequest, GatewayCache cache, Instant messageReceivedTime) throws GatewayException {
+    boolean alreadyCancelled = false;
+    ResponseEntity<Void> response = null;
     eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_PRE_SENDING,
         "Case Ref", "N/A",
         "TM Action", "CLOSE",
         "Source", "RM");
 
-    ResponseEntity<Void> response = cometRestClient.sendClose(rmRequest.getCaseId());
-    routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB, "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
+    try{
+      response = cometRestClient.sendClose(rmRequest.getCaseId());
+      routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CANCEL_TM_JOB, "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
+    } catch (RestClientException e) {
+      String tmResponse = e.getMessage();
+      if (tmResponse != null && tmResponse.contains("400") && tmResponse.contains("Case State must be Open")){
+        eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), CANCEL_ON_A_CANCEL,
+            "A cancel case has been received for a case that already has been cancelled",
+            "Message received: " + rmRequest.toString());
+        alreadyCancelled = true;
+      } else {
+        throw e;
+      }
+    }
 
     GatewayCache newCache = cacheService.getById(rmRequest.getCaseId());
     if (newCache == null) {
@@ -89,9 +105,13 @@ public class SpgCancelSiteProcessor implements InboundProcessor<FwmtCancelAction
           .lastActionTime(messageReceivedTime).build());
     }
 
-    eventManager
-        .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
-            "Case Ref", "N/A",
-            "Response Code", response.getStatusCode().name());
+
+    if (response != null && !alreadyCancelled) {
+      eventManager
+          .triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
+              "Case Ref", "N/A",
+              "Response Code", response.getStatusCode().name());
+
+    }
   }
 }

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/spg/SpgCancelUnitProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/spg/SpgCancelUnitProcessor.java
@@ -4,6 +4,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClientException;
 import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.ActionInstructionType;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
@@ -17,6 +18,7 @@ import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCEL_ON_A_CANCEL;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_ACK;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_PRE_SENDING;
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.FAILED_TO_CREATE_TM_JOB;
@@ -44,10 +46,6 @@ public class SpgCancelUnitProcessor implements InboundProcessor<FwmtCancelAction
       .addressLevel("U")
       .build();
 
-  public SpgCancelUnitProcessor(CometRestClient cometRestClient) {
-    this.cometRestClient = cometRestClient;
-  }
-
   @Override
   public ProcessorKey getKey() {
     return key;
@@ -69,13 +67,27 @@ public class SpgCancelUnitProcessor implements InboundProcessor<FwmtCancelAction
   // TODO Acceptance test should check close is sent (new event)
   @Override
   public void process(FwmtCancelActionInstruction rmRequest, GatewayCache cache, Instant messageReceivedTime) throws GatewayException {
+    boolean alreadyCancelled = false;
+    ResponseEntity<Void> response = null;
     eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_PRE_SENDING,
         "Case Ref", "N/A",
         "TM Action", "CLOSE",
         "Source", "RM");
-    
-    ResponseEntity<Void> response = cometRestClient.sendClose(rmRequest.getCaseId());
-    routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CREATE_TM_JOB, "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
+
+    try {
+      response = cometRestClient.sendClose(rmRequest.getCaseId());
+      routingValidator.validateResponseCode(response, rmRequest.getCaseId(), "Cancel", FAILED_TO_CREATE_TM_JOB, "rmRequest", rmRequest.toString(), "cache", (cache!=null)?cache.toString():"");
+    } catch (RestClientException e) {
+      String tmResponse = e.getMessage();
+      if (tmResponse != null && tmResponse.contains("400") && tmResponse.contains("Case State must be Open")){
+        eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), CANCEL_ON_A_CANCEL,
+            "A cancel case has been received for a case that already has been cancelled",
+            "Message received: " + rmRequest.toString());
+        alreadyCancelled = true;
+      } else {
+        throw e;
+      }
+    }
 
     GatewayCache newCache = cacheService.getById(rmRequest.getCaseId());
     if (newCache != null) {
@@ -83,10 +95,11 @@ public class SpgCancelUnitProcessor implements InboundProcessor<FwmtCancelAction
           .lastActionTime(messageReceivedTime)
           .build());
     }
-    
-    eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
-        "Case Ref", "N/A",
-        "Response Code", response.getStatusCode().name(),
-        "Source", "RM");
+    if (response != null && !alreadyCancelled) {
+      eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), COMET_CANCEL_ACK,
+          "Case Ref", "N/A",
+          "Response Code", response.getStatusCode().name(),
+          "Source", "RM");
+    }
   }
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/helper/FwmtCancelJobRequestBuilder.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/helper/FwmtCancelJobRequestBuilder.java
@@ -14,4 +14,66 @@ public class FwmtCancelJobRequestBuilder {
     fwmtCancelActionInstruction.setAddressType("CE");
     return fwmtCancelActionInstruction;
   }
+
+  public FwmtCancelActionInstruction cancelCeUnitActionInstruction() {
+    FwmtCancelActionInstruction fwmtCancelActionInstruction = new FwmtCancelActionInstruction();
+    fwmtCancelActionInstruction.setActionInstruction(ActionInstructionType.CANCEL);
+    fwmtCancelActionInstruction.setNc(false);
+    fwmtCancelActionInstruction.setCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002");
+    fwmtCancelActionInstruction.setAddressLevel("U");
+    fwmtCancelActionInstruction.setAddressType("CE");
+    return fwmtCancelActionInstruction;
+  }
+
+  public FwmtCancelActionInstruction cancelSpgSiteActionInstruction() {
+    FwmtCancelActionInstruction fwmtCancelActionInstruction = new FwmtCancelActionInstruction();
+    fwmtCancelActionInstruction.setActionInstruction(ActionInstructionType.CANCEL);
+    fwmtCancelActionInstruction.setNc(false);
+    fwmtCancelActionInstruction.setCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002");
+    fwmtCancelActionInstruction.setAddressLevel("E");
+    fwmtCancelActionInstruction.setAddressType("SPG");
+    return fwmtCancelActionInstruction;
+  }
+
+  public FwmtCancelActionInstruction cancelSpgUnitActionInstruction() {
+    FwmtCancelActionInstruction fwmtCancelActionInstruction = new FwmtCancelActionInstruction();
+    fwmtCancelActionInstruction.setActionInstruction(ActionInstructionType.CANCEL);
+    fwmtCancelActionInstruction.setNc(false);
+    fwmtCancelActionInstruction.setCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002");
+    fwmtCancelActionInstruction.setAddressLevel("U");
+    fwmtCancelActionInstruction.setAddressType("SPG");
+    return fwmtCancelActionInstruction;
+  }
+
+  public FwmtCancelActionInstruction cancelFeedbackActionInstruction() {
+    FwmtCancelActionInstruction fwmtCancelActionInstruction = new FwmtCancelActionInstruction();
+    fwmtCancelActionInstruction.setActionInstruction(ActionInstructionType.CANCEL);
+    fwmtCancelActionInstruction.setNc(false);
+    fwmtCancelActionInstruction.setCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002");
+    fwmtCancelActionInstruction.setAddressLevel("F");
+    fwmtCancelActionInstruction.setAddressType("FEEDBACK");
+    fwmtCancelActionInstruction.setSurveyName("FEEDBACK");
+    return fwmtCancelActionInstruction;
+  }
+
+  public FwmtCancelActionInstruction cancelCcsCeActionInstruction() {
+    FwmtCancelActionInstruction fwmtCancelActionInstruction = new FwmtCancelActionInstruction();
+    fwmtCancelActionInstruction.setActionInstruction(ActionInstructionType.CANCEL);
+    fwmtCancelActionInstruction.setNc(false);
+    fwmtCancelActionInstruction.setCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002");
+    fwmtCancelActionInstruction.setAddressLevel("E");
+    fwmtCancelActionInstruction.setAddressType("Ce");
+    fwmtCancelActionInstruction.setSurveyName("CCS");
+    return fwmtCancelActionInstruction;
+  }
+  public FwmtCancelActionInstruction cancelCcsHhActionInstruction() {
+    FwmtCancelActionInstruction fwmtCancelActionInstruction = new FwmtCancelActionInstruction();
+    fwmtCancelActionInstruction.setActionInstruction(ActionInstructionType.CANCEL);
+    fwmtCancelActionInstruction.setNc(false);
+    fwmtCancelActionInstruction.setCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002");
+    fwmtCancelActionInstruction.setAddressLevel("U");
+    fwmtCancelActionInstruction.setAddressType("CE");
+    fwmtCancelActionInstruction.setSurveyName("CCS");
+    return fwmtCancelActionInstruction;
+  }
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ccs/CcsCancelProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ccs/CcsCancelProcessorTest.java
@@ -1,0 +1,109 @@
+package uk.gov.ons.census.fwmt.jobservice.service.routing.ccs;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import uk.gov.ons.census.fwmt.common.error.GatewayException;
+import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
+import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
+import uk.gov.ons.census.fwmt.jobservice.data.GatewayCache;
+import uk.gov.ons.census.fwmt.jobservice.helper.FwmtCancelJobRequestBuilder;
+import uk.gov.ons.census.fwmt.jobservice.http.comet.CometRestClient;
+import uk.gov.ons.census.fwmt.jobservice.service.GatewayCacheService;
+import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCEL_ON_A_CANCEL;
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_ACK;
+
+@ExtendWith(MockitoExtension.class)
+public class CcsCancelProcessorTest {
+
+  @InjectMocks
+  private CcsInterviewCECancel ccsInterviewCECancel;
+
+  @InjectMocks
+  private CcsInterviewHHCancel ccsInterviewHHCancel;
+
+  @Mock
+  private CometRestClient cometRestClient;
+
+  @Mock
+  private GatewayEventManager eventManager;
+
+  @Mock
+  private RoutingValidator routingValidator;
+
+  @Mock
+  private GatewayCacheService cacheService;
+
+  @Captor
+  private ArgumentCaptor<String> spiedEvent;
+
+  @Test
+  @DisplayName("Should send a CCS CE cancel")
+  public void shouldSendACcsCeCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelCcsCeActionInstruction();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
+    ResponseEntity<Void> responseEntity = ResponseEntity.ok().build();
+    when(cometRestClient.sendClose(any())).thenReturn(responseEntity);
+    ccsInterviewCECancel.process(instruction, gatewayCache,  Instant.now());
+    verify(eventManager, atLeast(2)).triggerEvent(any(), spiedEvent.capture(), any());
+    String checkEvent = spiedEvent.getValue();
+    Assertions.assertEquals(COMET_CANCEL_ACK, checkEvent);
+  }
+
+  @Test
+  @DisplayName("Should ignore a CCS CE cancel on a cancel")
+  public void shouldIgnoreACcsCeCancelOnCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelCcsCeActionInstruction();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
+    when(cometRestClient.sendClose(any())).thenThrow(new RestClientException("(400 BAD_REQUEST) {“id”:[“Case State must be Open”]}"));
+    ccsInterviewCECancel.process(instruction, gatewayCache,  Instant.now());
+    verify(eventManager, atLeast(2)).triggerEvent(any(), spiedEvent.capture(), any());
+    String checkEvent = spiedEvent.getValue();
+    Assertions.assertEquals(CANCEL_ON_A_CANCEL, checkEvent);
+  }
+
+  @Test
+  @DisplayName("Should send a CCS HH cancel")
+  public void shouldSendACcsHhCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelCcsHhActionInstruction();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
+    ResponseEntity<Void> responseEntity = ResponseEntity.ok().build();
+    when(cometRestClient.sendClose(any())).thenReturn(responseEntity);
+    ccsInterviewHHCancel.process(instruction, gatewayCache,  Instant.now());
+    verify(eventManager, atLeast(2)).triggerEvent(any(), spiedEvent.capture(), any());
+    String checkEvent = spiedEvent.getValue();
+    Assertions.assertEquals(COMET_CANCEL_ACK, checkEvent);
+  }
+
+  @Test
+  @DisplayName("Should ignore a CCS HH cancel on a cancel")
+  public void shouldIgnoreACcsHhCancelOnCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelCcsHhActionInstruction();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
+    when(cometRestClient.sendClose(any())).thenThrow(new RestClientException("(400 BAD_REQUEST) {“id”:[“Case State must be Open”]}"));
+    ccsInterviewHHCancel.process(instruction, gatewayCache,  Instant.now());
+    verify(eventManager, atLeast(2)).triggerEvent(any(), spiedEvent.capture(), any());
+    String checkEvent = spiedEvent.getValue();
+    Assertions.assertEquals(CANCEL_ON_A_CANCEL, checkEvent);
+  }
+}

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCancelProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCancelProcessorTest.java
@@ -1,4 +1,4 @@
-package uk.gov.ons.census.fwmt.jobservice.service.routing.nc;
+package uk.gov.ons.census.fwmt.jobservice.service.routing.ce;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
@@ -15,15 +15,15 @@ import uk.gov.ons.census.fwmt.common.error.GatewayException;
 import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
 import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
 import uk.gov.ons.census.fwmt.jobservice.data.GatewayCache;
-import uk.gov.ons.census.fwmt.jobservice.helper.NcActionInstructionBuilder;
+import uk.gov.ons.census.fwmt.jobservice.helper.FwmtCancelJobRequestBuilder;
 import uk.gov.ons.census.fwmt.jobservice.http.comet.CometRestClient;
-import uk.gov.ons.census.fwmt.jobservice.http.rm.RmRestClient;
 import uk.gov.ons.census.fwmt.jobservice.service.GatewayCacheService;
 import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
 
 import java.time.Instant;
 
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.atLeast;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -31,34 +31,25 @@ import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCE
 import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_ACK;
 
 @ExtendWith(MockitoExtension.class)
-public class NcCancelProcessorTest {
+public class CeCancelProcessorTest {
 
   @InjectMocks
-  private NcHhCancel ncHhCancel;
+  private CeCancelEstabAndSiteProcessor ceCancelEstabAndSiteProcessor;
 
   @InjectMocks
-  private NcCeCancel ncCeCancel;
+  private CeCancelUnitProcessor ceCancelUnitProcessor;
 
   @Mock
   private CometRestClient cometRestClient;
 
   @Mock
-  private GatewayCacheService cacheService;
-
-  @Mock
-  private GatewayCache gatewayCache;
-
-  @Mock
   private GatewayEventManager eventManager;
-
-  @Mock
-  private RmRestClient rmRestClient;
 
   @Mock
   private RoutingValidator routingValidator;
 
   @Mock
-  private ResponseEntity<Void> responseEntity;
+  private GatewayCacheService cacheService;
 
   @Captor
   private ArgumentCaptor<GatewayCache> spiedCache;
@@ -67,53 +58,50 @@ public class NcCancelProcessorTest {
   private ArgumentCaptor<String> spiedEvent;
 
   @Test
-  @DisplayName("Should send cancel NC HH caseId to TM")
-  public void shouldHandleNCHHCancel() throws GatewayException {
-    final FwmtCancelActionInstruction instruction = new NcActionInstructionBuilder().createNcHhCancelInstruction();
+  @DisplayName("Should send a CE Estab cancel")
+  public void shouldSendACeEstabCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelActionInstruction();
     GatewayCache gatewayCache = GatewayCache.builder()
-        .caseId("c66c995e-571d-11eb-ae93-0242ac130002").careCodes("Mind dog").accessInfo("1234")
-        .originalCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATED").build();
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
     ResponseEntity<Void> responseEntity = ResponseEntity.ok().build();
-    when(cometRestClient.sendClose(gatewayCache.caseId)).thenReturn(responseEntity);
-    ncHhCancel.process(instruction, gatewayCache, Instant.now());
+    when(cometRestClient.sendClose(any())).thenReturn(responseEntity);
+    when(cacheService.getById(anyString())).thenReturn(gatewayCache);
+    ceCancelEstabAndSiteProcessor.process(instruction, gatewayCache,  Instant.now());
     verify(cacheService).save(spiedCache.capture());
-    String caseId = spiedCache.getValue().caseId;
-    String lastAction = spiedCache.getValue().lastActionInstruction;
-    Assertions.assertEquals("c66c995e-571d-11eb-ae93-0242ac130002", caseId);
-    Assertions.assertEquals("CANCEL", lastAction);
+    String lastActionInstruction = spiedCache.getValue().lastActionInstruction;
+    Assertions.assertEquals(instruction.getActionInstruction().toString(), lastActionInstruction);
     verify(eventManager, atLeast(2)).triggerEvent(any(), spiedEvent.capture(), any());
     String checkEvent = spiedEvent.getValue();
     Assertions.assertEquals(COMET_CANCEL_ACK, checkEvent);
   }
 
   @Test
-  @DisplayName("Should send cancel NC CE caseId to TM")
-  public void shouldHandleNCCECancel() throws GatewayException {
-    final FwmtCancelActionInstruction instruction = new NcActionInstructionBuilder().createNcCeCancelInstruction();
+  @DisplayName("Should send a CE Unit cancel")
+  public void shouldSendACeUnitCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelActionInstruction();
     GatewayCache gatewayCache = GatewayCache.builder()
-        .caseId("c66c995e-571d-11eb-ae93-0242ac130002").careCodes("Mind dog").accessInfo("1234")
-        .originalCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATED").build();
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
     ResponseEntity<Void> responseEntity = ResponseEntity.ok().build();
-    when(cometRestClient.sendClose(gatewayCache.caseId)).thenReturn(responseEntity);
-    ncCeCancel.process(instruction, gatewayCache, Instant.now());
+    when(cometRestClient.sendClose(any())).thenReturn(responseEntity);
+    when(cacheService.getById(anyString())).thenReturn(gatewayCache);
+    ceCancelUnitProcessor.process(instruction, gatewayCache,  Instant.now());
     verify(cacheService).save(spiedCache.capture());
-    String caseId = spiedCache.getValue().caseId;
-    String lastAction = spiedCache.getValue().lastActionInstruction;
-    Assertions.assertEquals("c66c995e-571d-11eb-ae93-0242ac130002", caseId);
-    Assertions.assertEquals("CANCEL", lastAction);
+    String lastActionInstruction = spiedCache.getValue().lastActionInstruction;
+    Assertions.assertEquals(instruction.getActionInstruction().toString(), lastActionInstruction);
     verify(eventManager, atLeast(2)).triggerEvent(any(), spiedEvent.capture(), any());
     String checkEvent = spiedEvent.getValue();
     Assertions.assertEquals(COMET_CANCEL_ACK, checkEvent);
   }
 
   @Test
-  @DisplayName("Should ignore a NC HH cancel on a cancel")
-  public void shouldIgnoreANcHHCancelOnCancel() throws GatewayException {
-    final FwmtCancelActionInstruction instruction = new NcActionInstructionBuilder().createNcHhCancelInstruction();
+  @DisplayName("Should ignore a CE Estab cancel on a cancel")
+  public void shouldIgnoreACeEstabCancelOnCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelActionInstruction();
     GatewayCache gatewayCache = GatewayCache.builder()
         .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
     when(cometRestClient.sendClose(any())).thenThrow(new RestClientException("(400 BAD_REQUEST) {“id”:[“Case State must be Open”]}"));
-    ncHhCancel.process(instruction, gatewayCache,  Instant.now());
+    when(cacheService.getById(anyString())).thenReturn(gatewayCache);
+    ceCancelEstabAndSiteProcessor.process(instruction, gatewayCache,  Instant.now());
     verify(cacheService).save(spiedCache.capture());
     String lastActionInstruction = spiedCache.getValue().lastActionInstruction;
     Assertions.assertEquals(instruction.getActionInstruction().toString(), lastActionInstruction);
@@ -123,13 +111,14 @@ public class NcCancelProcessorTest {
   }
 
   @Test
-  @DisplayName("Should ignore a NC CE cancel on a cancel")
-  public void shouldIgnoreANcCeCancelOnCancel() throws GatewayException {
-    final FwmtCancelActionInstruction instruction = new NcActionInstructionBuilder().createNcCeCancelInstruction();
+  @DisplayName("Should ignore a CE Unit cancel on a cancel")
+  public void shouldIgnoreACeUnitCancelOnCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelCeUnitActionInstruction();
     GatewayCache gatewayCache = GatewayCache.builder()
         .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
     when(cometRestClient.sendClose(any())).thenThrow(new RestClientException("(400 BAD_REQUEST) {“id”:[“Case State must be Open”]}"));
-    ncCeCancel.process(instruction, gatewayCache,  Instant.now());
+    when(cacheService.getById(anyString())).thenReturn(gatewayCache);
+    ceCancelUnitProcessor.process(instruction, gatewayCache,  Instant.now());
     verify(cacheService).save(spiedCache.capture());
     String lastActionInstruction = spiedCache.getValue().lastActionInstruction;
     Assertions.assertEquals(instruction.getActionInstruction().toString(), lastActionInstruction);

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/internal/FeedbackCancelProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/internal/FeedbackCancelProcessorTest.java
@@ -1,0 +1,91 @@
+package uk.gov.ons.census.fwmt.jobservice.service.routing.internal;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestClientException;
+import uk.gov.ons.census.fwmt.common.error.GatewayException;
+import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
+import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
+import uk.gov.ons.census.fwmt.jobservice.data.GatewayCache;
+import uk.gov.ons.census.fwmt.jobservice.helper.FwmtCancelJobRequestBuilder;
+import uk.gov.ons.census.fwmt.jobservice.http.comet.CometRestClient;
+import uk.gov.ons.census.fwmt.jobservice.service.GatewayCacheService;
+import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.CANCEL_ON_A_CANCEL;
+import static uk.gov.ons.census.fwmt.jobservice.config.GatewayEventsConfig.COMET_CANCEL_ACK;
+
+@ExtendWith(MockitoExtension.class)
+public class FeedbackCancelProcessorTest {
+
+  @InjectMocks
+  private FeedbackCancel feedbackCancel;
+
+  @Mock
+  private CometRestClient cometRestClient;
+
+  @Mock
+  private GatewayEventManager eventManager;
+
+  @Mock
+  private RoutingValidator routingValidator;
+
+  @Mock
+  private GatewayCacheService cacheService;
+
+  @Captor
+  private ArgumentCaptor<GatewayCache> spiedCache;
+
+  @Captor
+  private ArgumentCaptor<String> spiedEvent;
+
+  @Test
+  @DisplayName("Should send a Feedback cancel")
+  public void shouldSendAFeedbackCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelFeedbackActionInstruction();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
+    ResponseEntity<Void> responseEntity = ResponseEntity.ok().build();
+    when(cometRestClient.sendClose(any())).thenReturn(responseEntity);
+    when(cacheService.getById(anyString())).thenReturn(gatewayCache);
+    feedbackCancel.process(instruction, gatewayCache,  Instant.now());
+    verify(cacheService).save(spiedCache.capture());
+    String lastActionInstruction = spiedCache.getValue().lastActionInstruction;
+    Assertions.assertEquals(instruction.getActionInstruction().toString(), lastActionInstruction);
+    verify(eventManager, atLeast(2)).triggerEvent(any(), spiedEvent.capture(), any());
+    String checkEvent = spiedEvent.getValue();
+    Assertions.assertEquals(COMET_CANCEL_ACK, checkEvent);
+  }
+
+  @Test
+  @DisplayName("Should ignore a Feedback cancel on a cancel")
+  public void shouldIgnoreAFeedbackCancelOnCancel() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = new FwmtCancelJobRequestBuilder().cancelFeedbackActionInstruction();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").lastActionInstruction("CREATE").build();
+    when(cometRestClient.sendClose(any())).thenThrow(new RestClientException("(400 BAD_REQUEST) {“id”:[“Case State must be Open”]}"));
+    when(cacheService.getById(anyString())).thenReturn(gatewayCache);
+    feedbackCancel.process(instruction, gatewayCache,  Instant.now());
+    verify(cacheService).save(spiedCache.capture());
+    String lastActionInstruction = spiedCache.getValue().lastActionInstruction;
+    Assertions.assertEquals(instruction.getActionInstruction().toString(), lastActionInstruction);
+    verify(eventManager, atLeast(2)).triggerEvent(any(), spiedEvent.capture(), any());
+    String checkEvent = spiedEvent.getValue();
+    Assertions.assertEquals(CANCEL_ON_A_CANCEL, checkEvent);
+  }
+}


### PR DESCRIPTION
# Summary
[x] Bug fix ( non-breaking change which fixes issue)
[ ] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira:
https://collaborate2.ons.gov.uk/jira/browse/FWMT-3382

# Proposed Changes
Have added code to ignore any message where a cancel has been submitted but its state in TM is already cancelled. This affects all cancel processors with the exception of HH as these rely on pauses and not cancels. Have also added the related unit tests. 

# Checklist
- [x] Unit Test written 
- [ ] Acceptance Tests updated
- [ ] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )

# Additional Info
Run various cancels where the state of the case is cancelled in TM but our cache contains either a create or update action instruction.

# Screenshots

- Screen shot of Passed Unit/Acceptance Test

<img width="1680" alt="Screenshot 2021-03-05 at 09 43 41" src="https://user-images.githubusercontent.com/47788084/110098706-63ee6180-7d98-11eb-9a3a-d17fc6d5350b.png">
<img width="1680" alt="Screenshot 2021-03-05 at 09 44 50" src="https://user-images.githubusercontent.com/47788084/110098717-66e95200-7d98-11eb-89ec-711d140c34da.png">
<img width="1680" alt="Screenshot 2021-03-05 at 09 45 07" src="https://user-images.githubusercontent.com/47788084/110098732-69e44280-7d98-11eb-88c3-56bf1d529cd8.png">
<img width="1680" alt="Screenshot 2021-03-05 at 09 45 23" src="https://user-images.githubusercontent.com/47788084/110098740-6c469c80-7d98-11eb-8dfc-4fcd3a3aa314.png">
<img width="1678" alt="Screenshot 2021-03-05 at 09 45 39" src="https://user-images.githubusercontent.com/47788084/110098762-72d51400-7d98-11eb-9585-23eec1105c06.png">

