### PR TITLE
Have updated the CE estab and site create processors to be more stric…

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCreateEstabDeliverProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCreateEstabDeliverProcessor.java
@@ -60,7 +60,8 @@ public class CeCreateEstabDeliverProcessor implements InboundProcessor<FwmtActio
           && rmRequest.getAddressLevel().equals("E")
           && rmRequest.isHandDeliver()
           && (cache == null
-          || !cache.existsInFwmt)
+          || (!cache.existsInFwmt
+          && !cache.type.equals(3)))
           && !cacheService.doesEstabUprnExist(rmRequest.getUprn())
           && !rmRequest.isNc();
     } catch (NullPointerException e) {

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCreateEstabFollowupProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCreateEstabFollowupProcessor.java
@@ -64,7 +64,8 @@ public class CeCreateEstabFollowupProcessor implements InboundProcessor<FwmtActi
           && rmRequest.getAddressLevel().equals("E")
           && !rmRequest.isHandDeliver()
           && (cache == null
-          || cache.existsInFwmt)
+          || (cache.existsInFwmt
+          && !cache.type.equals(3)))
           && !cacheService.doesEstabUprnExist(rmRequest.getUprn())
           && !rmRequest.isNc();
     } catch (NullPointerException e) {

--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCreateSiteProcessor.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCreateSiteProcessor.java
@@ -59,7 +59,8 @@ public class CeCreateSiteProcessor implements InboundProcessor<FwmtActionInstruc
           && rmRequest.getAddressType().equals("CE")
           && rmRequest.getAddressLevel().equals("E")
           && (cache == null
-          || !cache.existsInFwmt)
+          || (!cache.existsInFwmt
+          && cache.type.equals(3)))
           && cacheService.doesEstabUprnExist(rmRequest.getUprn())
           && !rmRequest.isNc();
     } catch (NullPointerException e) {

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/helper/FwmtCreateJobRequestBuilder.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/helper/FwmtCreateJobRequestBuilder.java
@@ -1,0 +1,46 @@
+package uk.gov.ons.census.fwmt.jobservice.helper;
+
+import uk.gov.ons.census.fwmt.common.rm.dto.ActionInstructionType;
+import uk.gov.ons.census.fwmt.common.rm.dto.FwmtActionInstruction;
+
+public class FwmtCreateJobRequestBuilder {
+
+  public FwmtActionInstruction createCeEstabDeliver() {
+    FwmtActionInstruction fwmtActionInstruction = new FwmtActionInstruction();
+    fwmtActionInstruction.setActionInstruction(ActionInstructionType.CREATE);
+    fwmtActionInstruction.setCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002");
+    fwmtActionInstruction.setSurveyName("CENSUS");
+    fwmtActionInstruction.setAddressType("CE");
+    fwmtActionInstruction.setAddressLevel("E");
+    fwmtActionInstruction.setHandDeliver(true);
+    fwmtActionInstruction.setUprn("1234");
+    fwmtActionInstruction.setNc(false);
+    return fwmtActionInstruction;
+  }
+
+  public FwmtActionInstruction createCeEstabFollowup() {
+    FwmtActionInstruction fwmtActionInstruction = new FwmtActionInstruction();
+    fwmtActionInstruction.setActionInstruction(ActionInstructionType.CREATE);
+    fwmtActionInstruction.setCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002");
+    fwmtActionInstruction.setSurveyName("CENSUS");
+    fwmtActionInstruction.setAddressType("CE");
+    fwmtActionInstruction.setAddressLevel("E");
+    fwmtActionInstruction.setHandDeliver(false);
+    fwmtActionInstruction.setUprn("1234");
+    fwmtActionInstruction.setNc(false);
+    return fwmtActionInstruction;
+  }
+
+  public FwmtActionInstruction createCeSite() {
+    FwmtActionInstruction fwmtActionInstruction = new FwmtActionInstruction();
+    fwmtActionInstruction.setActionInstruction(ActionInstructionType.CREATE);
+    fwmtActionInstruction.setCaseId("ac623e62-4f4b-11eb-ae93-0242ac130002");
+    fwmtActionInstruction.setSurveyName("CENSUS");
+    fwmtActionInstruction.setAddressType("CE");
+    fwmtActionInstruction.setAddressLevel("E");
+    fwmtActionInstruction.setUprn("1234");
+    fwmtActionInstruction.setNc(false);
+    return fwmtActionInstruction;
+  }
+
+}

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCreateProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/ce/CeCreateProcessorTest.java
@@ -1,0 +1,86 @@
+package uk.gov.ons.census.fwmt.jobservice.service.routing.ce;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ons.census.fwmt.common.rm.dto.FwmtActionInstruction;
+import uk.gov.ons.census.fwmt.jobservice.data.GatewayCache;
+import uk.gov.ons.census.fwmt.jobservice.helper.FwmtCreateJobRequestBuilder;
+import uk.gov.ons.census.fwmt.jobservice.service.GatewayCacheService;
+
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+public class CeCreateProcessorTest {
+
+  @InjectMocks
+  private CeCreateEstabDeliverProcessor ceCreateEstabDeliverProcessor;
+
+  @InjectMocks
+  private CeCreateEstabFollowupProcessor ceCreateEstabFollowupProcessor;
+
+  @InjectMocks
+  private CeCreateSiteProcessor ceCreateSiteProcessor;
+
+  @Mock
+  private GatewayCacheService cacheService;
+
+  @Test
+  @DisplayName("Should not select CE Estab Deliver Create processor")
+  public void shouldNotSelectCeEstabDeliverCreateProcessor() {
+    final FwmtActionInstruction instruction = new FwmtCreateJobRequestBuilder().createCeEstabDeliver();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").estabUprn("4321").existsInFwmt(false).type(3).lastActionInstruction("CREATE").build();
+    Assertions.assertFalse(ceCreateEstabDeliverProcessor.isValid(instruction, gatewayCache));
+  }
+
+  @Test
+  @DisplayName("Should select CE Estab Deliver Create processor")
+  public void shouldSelectCeEstabDeliverCreateProcessor() {
+    final FwmtActionInstruction instruction = new FwmtCreateJobRequestBuilder().createCeEstabDeliver();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").estabUprn("4321").existsInFwmt(false).type(1).lastActionInstruction("CREATE").build();
+    Assertions.assertTrue(ceCreateEstabDeliverProcessor.isValid(instruction, gatewayCache));
+  }
+
+  @Test
+  @DisplayName("Should not select CE Estab Followup Create processor")
+  public void shouldNotSelectCeEstabFollowupCreateProcessor() {
+    final FwmtActionInstruction instruction = new FwmtCreateJobRequestBuilder().createCeEstabFollowup();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").estabUprn("4321").existsInFwmt(true).type(3).lastActionInstruction("CREATE").build();
+    Assertions.assertFalse(ceCreateEstabFollowupProcessor.isValid(instruction, gatewayCache));
+  }
+
+  @Test
+  @DisplayName("Should select CE Estab Followup Create processor")
+  public void shouldSelectCeEstabFollowupCreateProcessor() {
+    final FwmtActionInstruction instruction = new FwmtCreateJobRequestBuilder().createCeEstabFollowup();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").estabUprn("4321").existsInFwmt(true).type(1).lastActionInstruction("CREATE").build();
+    Assertions.assertTrue(ceCreateEstabFollowupProcessor.isValid(instruction, gatewayCache));
+  }
+
+  @Test
+  @DisplayName("Should not select CE Site Create processor")
+  public void shouldNotSelectCeSiteCreateProcessor() {
+    final FwmtActionInstruction instruction = new FwmtCreateJobRequestBuilder().createCeSite();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").estabUprn("1234").existsInFwmt(false).type(10).lastActionInstruction("CREATE").build();
+    Assertions.assertFalse(ceCreateSiteProcessor.isValid(instruction, gatewayCache));
+  }
+
+  @Test
+  @DisplayName("Should select CE Site Create processor")
+  public void shouldSelectCeSiteCreateProcessor() {
+    final FwmtActionInstruction instruction = new FwmtCreateJobRequestBuilder().createCeSite();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").estabUprn("1234").existsInFwmt(false).type(3).lastActionInstruction("CREATE").build();
+    when(cacheService.doesEstabUprnExist(instruction.getUprn())).thenReturn(true);
+    Assertions.assertTrue(ceCreateSiteProcessor.isValid(instruction, gatewayCache));
+  }
+}


### PR DESCRIPTION
…t and avoid turning a HH into a CE site during a switch

# Summary
[x] Bug fix ( non-breaking change which fixes issue)
[ ] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira 
https://collaborate2.ons.gov.uk/jira/browse/FWMT-3387

# Proposed Changes
The 2 CE estab and CE site create processors have both been updated to have stricter rules and to prevent a HH being turned into a CE site during a switch. Have also added unit tests.

# Checklist
- [x] Unit Test written 
- [ ] Acceptance Tests updated
- [ ] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )

# Additional Info
Run a HH switch.

# Screenshots

- Screen shot of Passed Unit/Acceptance Test

<img width="1680" alt="Screenshot 2021-03-09 at 10 21 19" src="https://user-images.githubusercontent.com/47788084/110456895-fc028880-80c1-11eb-971d-01aceeee6e77.png">
