### PR TITLE
Fwmt 3444 add hh cancel held processor

### DIFF
--- a/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/hh/HhCancelHeld.java
+++ b/src/main/java/uk/gov/ons/census/fwmt/jobservice/service/routing/hh/HhCancelHeld.java
@@ -1,0 +1,61 @@
+package uk.gov.ons.census.fwmt.jobservice.service.routing.hh;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Service;
+import uk.gov.ons.census.fwmt.common.error.GatewayException;
+import uk.gov.ons.census.fwmt.common.rm.dto.ActionInstructionType;
+import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
+import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
+import uk.gov.ons.census.fwmt.jobservice.data.GatewayCache;
+import uk.gov.ons.census.fwmt.jobservice.service.processor.InboundProcessor;
+import uk.gov.ons.census.fwmt.jobservice.service.processor.ProcessorKey;
+
+import java.time.Instant;
+
+@Qualifier("Cancel")
+@Service
+public class HhCancelHeld implements InboundProcessor<FwmtCancelActionInstruction> {
+
+  private static final String HH_CANCEL_HELD = "HH_CANCEL_HELD";
+
+  public static final String COMET_CANCEL_PRE_SENDING = "COMET_CANCEL_PRE_SENDING";
+
+  public static final String COMET_CANCEL_ACK = "COMET_CANCEL_ACK";
+
+  private static final ProcessorKey key = ProcessorKey.builder()
+      .actionInstruction(ActionInstructionType.CANCEL.toString())
+      .surveyName("CENSUS")
+      .addressType("HH")
+      .addressLevel("U")
+      .build();
+
+  @Autowired
+  private GatewayEventManager eventManager;
+
+  @Override
+  public ProcessorKey getKey() {
+    return key;
+  }
+
+  @Override public boolean isValid(FwmtCancelActionInstruction rmRequest, GatewayCache cache) {
+    try {
+      return rmRequest.getActionInstruction() == ActionInstructionType.CANCEL
+          && rmRequest.getSurveyName().equals("CENSUS")
+          && rmRequest.getAddressType().equals("HH")
+          && rmRequest.getAddressLevel().equals("U")
+          && !rmRequest.isNc()
+          && (cache == null
+          || !cache.existsInFwmt);
+    } catch (NullPointerException e) {
+      return false;
+    }
+  }
+
+  @Override public void process(FwmtCancelActionInstruction rmRequest, GatewayCache cache, Instant messageReceivedTime)
+      throws GatewayException {
+
+    eventManager.triggerEvent(String.valueOf(rmRequest.getCaseId()), HH_CANCEL_HELD,
+        "A HH Cancel was received before a create. Create does not exist in cache and so will be held.");
+  }
+}

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/hh/HHCancelHeldProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/hh/HHCancelHeldProcessorTest.java
@@ -64,4 +64,5 @@ class HHCancelHeldProcessorTest {
     String checkEvent = spiedEvent.getValue();
     Assertions.assertEquals(HH_CANCEL_HELD, checkEvent);
   }
+
 }

--- a/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/hh/HHCancelHeldProcessorTest.java
+++ b/src/test/java/uk/gov/ons/census/fwmt/jobservice/service/routing/hh/HHCancelHeldProcessorTest.java
@@ -1,0 +1,67 @@
+package uk.gov.ons.census.fwmt.jobservice.service.routing.hh;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import uk.gov.ons.census.fwmt.common.error.GatewayException;
+import uk.gov.ons.census.fwmt.common.rm.dto.FwmtCancelActionInstruction;
+import uk.gov.ons.census.fwmt.events.component.GatewayEventManager;
+import uk.gov.ons.census.fwmt.jobservice.data.GatewayCache;
+import uk.gov.ons.census.fwmt.jobservice.hh.HhRequestBuilder;
+import uk.gov.ons.census.fwmt.jobservice.http.comet.CometRestClient;
+import uk.gov.ons.census.fwmt.jobservice.service.routing.RoutingValidator;
+
+import java.time.Instant;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeast;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class HHCancelHeldProcessorTest {
+
+  @InjectMocks
+  private HhCancelHeld hhCancelHeld;
+
+  @Mock
+  private CometRestClient cometRestClient;
+
+  @Mock
+  private GatewayEventManager eventManager;
+
+  @Mock
+  private RoutingValidator routingValidator;
+
+  @Captor
+  private ArgumentCaptor<String> spiedEvent;
+
+  private static final String HH_CANCEL_HELD = "HH_CANCEL_HELD";
+
+  @Test
+  @DisplayName("Should hold a HH cancel that does not exists in FWMT")
+  public void shouldHoldAHhCancelThatDoesNotExistInFwmt() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = HhRequestBuilder.cancelActionInstruction();
+    GatewayCache gatewayCache = GatewayCache.builder()
+        .caseId("ac623e62-4f4b-11eb-ae93-0242ac130002").existsInFwmt(false).build();
+    hhCancelHeld.process(instruction, gatewayCache,  Instant.now());
+    verify(eventManager, atLeast(1)).triggerEvent(any(), spiedEvent.capture(), any());
+    String checkEvent = spiedEvent.getValue();
+    Assertions.assertEquals(HH_CANCEL_HELD, checkEvent);
+  }
+
+  @Test
+  @DisplayName("Should hold a HH cancel that does not exists in cache")
+  public void shouldHoldAHhCancelThatDoesNotExistInCache() throws GatewayException {
+    final FwmtCancelActionInstruction instruction = HhRequestBuilder.cancelActionInstruction();
+    hhCancelHeld.process(instruction, null,  Instant.now());
+    verify(eventManager, atLeast(1)).triggerEvent(any(), spiedEvent.capture(), any());
+    String checkEvent = spiedEvent.getValue();
+    Assertions.assertEquals(HH_CANCEL_HELD, checkEvent);
+  }
+}


### PR DESCRIPTION
# Summary
[x] Bug fix ( non-breaking change which fixes issue)
[ ] New Feature ( non-breaking change which adds functionality )
[ ] Breaking Change (fix or feature that would cause existing functionality to change)

- Link to issue in Jira 
FWMT-3444

# Proposed Changes
Have added a new processor to process any HH cancel that does not exist in fwmt or does not exist in cache. Cancel will be held. Have also added associated unit tests.

# Checklist
- [x] Unit Test written 
- [ ] Acceptance Tests updated
- [ ] Documentation Updated 
- [ ] Dependencies updated?  ( services, libraries)?
- [x] SonarLint -  ( use the plugin )

# Additional Info
Run a HH cancel on a case that has not been created.

# Screenshots

- Screen shot of Passed Unit/Acceptance Test

<img width="1680" alt="Screenshot 2021-04-01 at 13 11 13" src="https://user-images.githubusercontent.com/47788084/113292684-be71d380-92ec-11eb-82bd-e2eeab498f8b.png">

